### PR TITLE
feat: add server validation CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ agent = [
 
 [project.scripts]
 mcp-server = "mcp_server.server:main"
+validate-server = "scripts.validate_server:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,13 @@
+# Scripts
+
+## validate_server.py
+
+Validates that tools are registered with the MCP server.
+
+```bash
+uv run validate-server
+# or
+uv run python scripts/validate_server.py
+```
+
+The command prints a JSON summary listing tool names and the total count.

--- a/scripts/validate_server.py
+++ b/scripts/validate_server.py
@@ -1,17 +1,26 @@
-"""Validate MCP server functionality."""
+"""Validate registered tools in the MCP server.
 
-import asyncio
+Usage:
+    uv run validate-server
+    # or
+    uv run python scripts/validate_server.py
+"""
 
-from mcp_server.server import create_server
+from __future__ import annotations
+
+import json
+
+import anyio
+
+from mcp_server.server import mcp, register_tools
 
 
 def main() -> None:
-    server = create_server("Validation")
-    tool_registry = getattr(server, "_tool_registry", {})
-    summary = {
-        "tool_count": len(tool_registry),
-        "tools": sorted(tool_registry.keys()),
-    }
+    """Register tools and print summary."""
+    register_tools()
+    tools = anyio.run(mcp.get_tools)
+    names = sorted(tools.keys())
+    summary = {"tool_count": len(names), "tools": names}
     print(json.dumps(summary, indent=2))
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,7 @@
 """Server structure tests using singleton registration pattern."""
 
+import anyio
+
 from mcp_server.server import mcp, register_tools
 
 
@@ -12,5 +14,5 @@ class TestServerStructure:
 
     def test_tool_registration_count(self) -> None:
         register_tools()
-        names = {t.name for t in getattr(mcp, "tools", [])}
-        assert {"convert_timezone", "to_unix_time"}.issubset(names)
+        tools = anyio.run(mcp.get_tools)
+        assert {"convert_timezone", "to_unix_time"}.issubset(tools.keys())


### PR DESCRIPTION
## Summary
- replace outdated validation script with CLI using singleton `mcp`
- document validation usage in `scripts/README`
- expose `validate-server` console entry and adapt server test

## Testing
- `make format`
- `make lint`
- `make mypy` *(fails: Returning Any from function declared to return dict[str, Any]; missing stubs for dateutil; no-any-return; incompatible types in assignment)*
- `make test` *(fails: Client failed to connect: All connection attempts failed)*


------
https://chatgpt.com/codex/tasks/task_e_689acd2892f483269a7deb06d4af90ec