### PR TITLE
feat: add structlog-based logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "typing-extensions>=4.9",
     "starlette>=0.36",
     "uvicorn>=0.29",
+    "structlog>=24.1",
 ]
 
 [project.optional-dependencies]
@@ -40,6 +41,7 @@ dev = [
     "ruff>=0.3",
     "black>=24.0",
     "pre-commit>=3.6",
+    "types-python-dateutil>=2.9",
 ]
 
 agent = [
@@ -77,6 +79,7 @@ dev-dependencies = [
     "ruff>=0.3",
     "black>=24.0",
     "ipython>=8.20",
+    "types-python-dateutil>=2.9",
 ]
 
 [tool.pytest.ini_options]

--- a/src/mcp_server/core/__init__.py
+++ b/src/mcp_server/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core package for MCP server utilities."""
+
+from .logging import configure_logging
+
+__all__ = ["configure_logging"]

--- a/src/mcp_server/core/logging.py
+++ b/src/mcp_server/core/logging.py
@@ -1,0 +1,23 @@
+"""Logging configuration for the MCP server."""
+
+from __future__ import annotations
+
+import logging
+
+import structlog
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Configure structlog and the standard logging module."""
+    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.JSONRenderer(),
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -1,15 +1,14 @@
 """MCP Server implementation using FastMCP."""
 
-import logging
-
+import structlog
 from fastmcp import FastMCP
 from starlette.middleware.cors import CORSMiddleware
 
 from mcp_server.config import get_config
+from mcp_server.core.logging import configure_logging
 from mcp_server.tools import convert_timezone, to_unix_time
-from mcp_server.utils import setup_logging
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # Singleton FastMCP instance
 app_name = "MCP Server Template"
@@ -35,7 +34,7 @@ def register_tools() -> None:
 def main() -> None:
     """Main entry point for the server."""
     config = get_config()
-    setup_logging(config.log_level)
+    configure_logging(config.log_level)
     logger.info("Starting MCP server on %s:%s%s", config.host, config.port, config.path)
     register_tools()
     # Serve HTTP using configuration values (overridable via environment variables)

--- a/src/mcp_server/utils.py
+++ b/src/mcp_server/utils.py
@@ -1,16 +1,12 @@
 """Utility functions for the MCP server."""
 
-import logging
-from datetime import datetime, timezone
-from typing import Optional
-
-from dateutil import parser as dateutil_parser
+from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
 
-logger = logging.getLogger(__name__)
+from dateutil import parser as dateutil_parser
 
 
-def parse_datetime(dt: str, assume_tz: Optional[str] = None) -> datetime:
+def parse_datetime(dt: str, assume_tz: str | None = None) -> datetime:
     """Parse a wide range of datetime strings into an aware datetime.
 
     - Accepts ISO 8601, 'YYYY-MM-DD HH:MM', 'YYYY/MM/DD HH:MM:SS', etc.
@@ -23,13 +19,5 @@ def parse_datetime(dt: str, assume_tz: Optional[str] = None) -> datetime:
         if assume_tz:
             parsed = parsed.replace(tzinfo=ZoneInfo(assume_tz))
         else:
-            parsed = parsed.replace(tzinfo=timezone.utc)
+            parsed = parsed.replace(tzinfo=UTC)
     return parsed
-
-
-def setup_logging(level: str = "INFO") -> None:
-    """Setup structured logging for the server."""
-    logging.basicConfig(
-        level=getattr(logging, level.upper(), logging.INFO),
-        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-    )

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ version = "3.22.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "docstring-parser", marker = "python_full_version < '4'" },
     { name = "rich" },
     { name = "rich-rst" },
 ]
@@ -889,6 +889,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pytz" },
     { name = "starlette" },
+    { name = "structlog" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
 ]
@@ -907,6 +908,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-python-dateutil" },
 ]
 
 [package.dev-dependencies]
@@ -918,6 +920,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-python-dateutil" },
 ]
 
 [package.metadata]
@@ -939,6 +942,8 @@ requires-dist = [
     { name = "pytz", specifier = ">=2024.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3" },
     { name = "starlette", specifier = ">=0.36" },
+    { name = "structlog", specifier = ">=24.1" },
+    { name = "types-python-dateutil", marker = "extra == 'dev'", specifier = ">=2.9" },
     { name = "typing-extensions", specifier = ">=4.9" },
     { name = "uvicorn", specifier = ">=0.29" },
 ]
@@ -953,6 +958,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.3" },
+    { name = "types-python-dateutil", specifier = ">=2.9" },
 ]
 
 [[package]]
@@ -1748,6 +1754,15 @@ wheels = [
 ]
 
 [[package]]
+name = "structlog"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/b9/6e672db4fec07349e7a8a8172c1a6ae235c58679ca29c3f86a61b5e59ff3/structlog-25.4.0.tar.gz", hash = "sha256:186cd1b0a8ae762e29417095664adf1d6a31702160a46dacb7796ea82f7409e4", size = 1369138, upload-time = "2025-06-02T08:21:12.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/4a/97ee6973e3a73c74c8120d59829c3861ea52210667ec3e7a16045c62b64d/structlog-25.4.0-py3-none-any.whl", hash = "sha256:fe809ff5c27e557d14e613f45ca441aabda051d119ee5a0102aaba6ce40eed2c", size = 68720, upload-time = "2025-06-02T08:21:11.43Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1793,6 +1808,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20250809"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/53/07dac71db45fb6b3c71c2fd29a87cada2239eac7ecfb318e6ebc7da00a3b/types_python_dateutil-2.9.0.20250809.tar.gz", hash = "sha256:69cbf8d15ef7a75c3801d65d63466e46ac25a0baa678d89d0a137fc31a608cc1", size = 15820, upload-time = "2025-08-09T03:14:14.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/5e/67312e679f612218d07fcdbd14017e6d571ce240a5ba1ad734f15a8523cc/types_python_dateutil-2.9.0.20250809-py3-none-any.whl", hash = "sha256:768890cac4f2d7fd9e0feb6f3217fce2abbfdfc0cadd38d11fba325a815e4b9f", size = 17707, upload-time = "2025-08-09T03:14:13.314Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- configure structlog in new `mcp_server.core.logging` module
- remove legacy `setup_logging` from utils and wire server to use the new configuration
- add `structlog` and `types-python-dateutil` to project dependencies

## Testing
- `uv run ruff check --no-fix src/mcp_server/server.py src/mcp_server/utils.py src/mcp_server/core/logging.py tests/test_server.py tests/test_tools/test_time_tools.py`
- `make mypy`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ad77b86b88326bd7268a96a27e752