### PR TITLE
chore: drop unused deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ mypy src/
 
 ```bash
 # Format code
-black src/ tests/
 ruff format src/ tests/
 
 # Lint

--- a/USE_AS_TEMPLATE.md
+++ b/USE_AS_TEMPLATE.md
@@ -70,7 +70,6 @@ Create a new file `src/mcp_server/tools/my_api_tools.py`:
 ```python
 """Tools for integrating with My API service."""
 from typing import Annotated, Optional
-import httpx
 from pydantic import BaseModel
 
 
@@ -90,18 +89,15 @@ async def get_user_data(
     Perfect for AI agents that need access to user data.
     """
     try:
-        async with httpx.AsyncClient() as client:
-            url = f"https://my-api.com/users/{user_id}"
-            params = {"details": include_details}
-            response = await client.get(url, params=params)
-            response.raise_for_status()
-            
-            return ApiResponse(
-                data=response.json(),
-                status="success"
-            )
-    except httpx.HTTPStatusError as e:
-        raise ValueError(f"API request failed: {e.response.status_code}")
+        # Use your preferred HTTP client to fetch data from your API
+        data = {
+            "id": user_id,
+            "details": include_details,
+        }
+        return ApiResponse(
+            data=data,
+            status="success",
+        )
     except Exception as e:
         raise RuntimeError(f"Failed to fetch user data: {e}")
 
@@ -234,7 +230,7 @@ async def send_notification(
     priority: Annotated[str, "Priority level"] = "normal",
 ) -> bool:
     """Send notification via external service."""
-    # Implementation with requests/httpx
+    # Implementation with requests
     pass
 ```
 
@@ -276,7 +272,6 @@ dependencies = [
     "fastmcp>=2.0",
     "pydantic>=2.5",
     # Add your dependencies:
-    "httpx>=0.27",        # For HTTP clients
     "asyncpg>=0.29",      # For PostgreSQL
     "boto3>=1.34",        # For AWS services
     "redis>=5.0",         # For caching

--- a/docs/fastmcp documentation/Running Your FastMCP Server.md
+++ b/docs/fastmcp documentation/Running Your FastMCP Server.md
@@ -73,7 +73,7 @@ fastmcp run server.py --with pandas --with numpy
 fastmcp run server.py --with-requirements requirements.txt
 
 # Combine multiple options
-fastmcp run server.py --python 3.10 --with httpx --transport http
+fastmcp run server.py --python 3.10 --with pandas --transport http
 
 # Run within a specific project directory
 fastmcp run server.py --project /path/to/project

--- a/docs/mcp_template.md
+++ b/docs/mcp_template.md
@@ -67,10 +67,7 @@ dependencies = [
     "fastmcp>=2.0",
     "pydantic>=2.5",
     "python-dateutil>=2.9",
-    "pytz>=2024.1",
     "python-dotenv>=1.0",
-    "httpx>=0.27",
-    "typing-extensions>=4.9",
 ]
 
 [project.optional-dependencies]
@@ -80,7 +77,6 @@ dev = [
     "pytest-cov>=5.0",
     "mypy>=1.8",
     "ruff>=0.3",
-    "black>=24.0",
     "pre-commit>=3.6",
 ]
 
@@ -104,7 +100,6 @@ dev-dependencies = [
     "pytest-cov>=5.0",
     "mypy>=1.8",
     "ruff>=0.3",
-    "black>=24.0",
     "ipython>=8.20",
 ]
 
@@ -159,7 +154,7 @@ select = [
     "SIM",  # flake8-simplify
 ]
 ignore = [
-    "E501",  # line too long (handled by black)
+    "E501",  # line too long (handled by formatter)
     "B008",  # do not perform function calls in argument defaults
 ]
 
@@ -168,11 +163,6 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
-
-[tool.black]
-line-length = 100
-target-version = ["py313"]
-include = '\.pyi?$'
 ```
 
 ### src/mcp_server/__init__.py
@@ -1216,7 +1206,6 @@ mypy src/
 
 ```bash
 # Format code
-black src/ tests/
 ruff format src/ tests/
 
 # Lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,7 @@ dependencies = [
     "fastmcp>=2.0",
     "pydantic>=2.5",
     "python-dateutil>=2.9",
-    "pytz>=2024.1",
     "python-dotenv>=1.0",
-    "httpx>=0.27",
-    "typing-extensions>=4.9",
     "starlette>=0.36",
     "uvicorn>=0.29",
     "structlog>=24.1",
@@ -39,7 +36,6 @@ dev = [
     "pytest-cov>=5.0",
     "mypy>=1.8",
     "ruff>=0.3",
-    "black>=24.0",
     "pre-commit>=3.6",
     "types-python-dateutil>=2.9",
 ]
@@ -77,7 +73,6 @@ dev-dependencies = [
     "pytest-cov>=5.0",
     "mypy>=1.8",
     "ruff>=0.3",
-    "black>=24.0",
     "ipython>=8.20",
     "types-python-dateutil>=2.9",
 ]
@@ -142,8 +137,3 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
-
-[tool.black]
-line-length = 100
-target-version = ["py313"]
-include = '\\.pyi?$'

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -4,7 +4,7 @@ This package provides an MCP (Model Context Protocol) server implementation
 using the FastMCP framework.
 """
 
-from .models import TimezoneConvertInput, UnixTimeInput, ToolResult
+from .models import TimezoneConvertInput, ToolResult, UnixTimeInput
 
 __version__ = "0.1.0"
 __all__ = ["TimezoneConvertInput", "UnixTimeInput", "ToolResult"]

--- a/src/mcp_server/models.py
+++ b/src/mcp_server/models.py
@@ -1,8 +1,7 @@
 """Pydantic models for type safety and validation."""
 
-from datetime import datetime
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -32,7 +31,7 @@ class TimezoneConvertInput(BaseModel):
         examples=["America/New_York", "Europe/London", "UTC"],
         description="Target IANA timezone.",
     )
-    out_format: Optional[str] = Field(
+    out_format: str | None = Field(
         None,
         examples=["%Y-%m-%d %H:%M", "%d/%m/%Y %I:%M %p"],
         description="Optional strftime format; if omitted returns ISO 8601.",
@@ -54,7 +53,7 @@ class UnixTimeInput(BaseModel):
         examples=["2025-08-10T09:30:00+02:00", "2025-08-10 09:30", "1754899800"],
         description="Datetime (string) or numeric unix timestamp to convert.",
     )
-    tz: Optional[str] = Field(
+    tz: str | None = Field(
         None,
         examples=["Europe/Madrid", "America/New_York"],
         description="Assumed IANA timezone if dt is naive; default UTC.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,9 @@
 
 import asyncio
 import sys
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import pytest
 from mcp.server.fastmcp import FastMCP
@@ -16,7 +17,7 @@ from mcp_server.server import mcp, register_tools  # noqa: E402
 
 
 @pytest.fixture(scope="session")
-def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
+def event_loop() -> Generator[asyncio.AbstractEventLoop]:
     """Create event loop for async tests."""
     loop = asyncio.new_event_loop()
     yield loop

--- a/uv.lock
+++ b/uv.lock
@@ -55,26 +55,6 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/94/49/26a7b0f3f35da4b5a65f081943b7bcd22d7002f5f0fb8098ec1ff21cb6ef/black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666", size = 649449, upload-time = "2025-01-29T04:15:40.373Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/87/0edf98916640efa5d0696e1abb0a8357b52e69e82322628f25bf14d263d1/black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f", size = 1650673, upload-time = "2025-01-29T05:37:20.574Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e5/f7bf17207cf87fa6e9b676576749c6b6ed0d70f179a3d812c997870291c3/black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3", size = 1453190, upload-time = "2025-01-29T05:37:22.106Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926, upload-time = "2025-01-29T04:18:58.564Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613, upload-time = "2025-01-29T04:19:27.63Z" },
-    { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646, upload-time = "2025-01-29T04:15:38.082Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -883,14 +863,11 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
-    { name = "httpx" },
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
-    { name = "pytz" },
     { name = "starlette" },
     { name = "structlog" },
-    { name = "typing-extensions" },
     { name = "uvicorn" },
 ]
 
@@ -901,7 +878,6 @@ agent = [
     { name = "langgraph" },
 ]
 dev = [
-    { name = "black" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -913,7 +889,6 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
     { name = "ipython" },
     { name = "mypy" },
     { name = "pytest" },
@@ -925,9 +900,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=24.0" },
     { name = "fastmcp", specifier = ">=2.0" },
-    { name = "httpx", specifier = ">=0.27" },
     { name = "langchain", extras = ["openai"], marker = "extra == 'agent'", specifier = ">=0.1" },
     { name = "langchain-mcp-adapters", marker = "extra == 'agent'", specifier = ">=0.1.9" },
     { name = "langgraph", marker = "extra == 'agent'", specifier = ">=0.2" },
@@ -939,19 +912,16 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "python-dateutil", specifier = ">=2.9" },
     { name = "python-dotenv", specifier = ">=1.0" },
-    { name = "pytz", specifier = ">=2024.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3" },
     { name = "starlette", specifier = ">=0.36" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "types-python-dateutil", marker = "extra == 'dev'", specifier = ">=2.9" },
-    { name = "typing-extensions", specifier = ">=4.9" },
     { name = "uvicorn", specifier = ">=0.29" },
 ]
 provides-extras = ["dev", "agent"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=24.0" },
     { name = "ipython", specifier = ">=8.20" },
     { name = "mypy", specifier = ">=1.8" },
     { name = "pytest", specifier = ">=8.0" },
@@ -1430,15 +1400,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
-]
-
-[[package]]
-name = "pytz"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- remove unused dependencies and black from dev extras
- refresh docs to stop referencing pytz, httpx, typing-extensions, or black
- run ruff fixes and refresh lockfile

## Testing
- `make format`
- `uv run ruff check --no-fix src tests`
- `make mypy`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689af78720a88326bcb0fed7ae7f2666