### PR TITLE
refactor: use pydantic models for time tools

### DIFF
--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -18,8 +18,10 @@ mcp = FastMCP(app_name)
 def register_tools() -> None:
     """Register all tool functions with the MCP server.
 
-    Idempotent: calling multiple times won't duplicate registrations due to
-    FastMCP's internal handling (safe in test setups).
+    Tools accept Pydantic input models (``TimezoneConvertInput`` and
+    ``UnixTimeInput``) for validation. Idempotent: calling multiple times won't
+    duplicate registrations due to FastMCP's internal handling (safe in test
+    setups).
     """
     registered_before = {t.name for t in getattr(mcp, "tools", [])}
     # Core tools

--- a/src/mcp_server/tools/time_tools.py
+++ b/src/mcp_server/tools/time_tools.py
@@ -1,51 +1,33 @@
 """Time and timezone related tools."""
 
-from typing import Annotated, Literal
 from zoneinfo import ZoneInfo
 
+from mcp_server.models import TimeUnit, TimezoneConvertInput, UnixTimeInput
 from mcp_server.utils import parse_datetime
 
 
-def convert_timezone(
-    dt: Annotated[str, "Datetime to convert (ISO 8601 or commonly parseable)"],
-    from_tz: Annotated[str, "IANA time zone of the input (e.g., 'Europe/Madrid')"],
-    to_tz: Annotated[str, "Target IANA time zone (e.g., 'America/New_York')"],
-    out_format: Annotated[
-        str | None,
-        "Optional Python strftime format (default ISO 8601)",
-    ] = None,
-) -> str:
+def convert_timezone(data: TimezoneConvertInput) -> str:
     """Convert a datetime from one IANA time zone to another.
 
     Returns ISO 8601 by default, or a custom strftime if provided.
     """
-    aware_dt = parse_datetime(dt, assume_tz=from_tz)
-    converted = aware_dt.astimezone(ZoneInfo(to_tz))
-    return converted.isoformat() if not out_format else converted.strftime(out_format)
+    aware_dt = parse_datetime(data.dt, assume_tz=data.from_tz)
+    converted = aware_dt.astimezone(ZoneInfo(data.to_tz))
+    return converted.isoformat() if data.out_format is None else converted.strftime(data.out_format)
 
 
-def to_unix_time(
-    dt: Annotated[str, "Datetime to convert (ISO 8601, common formats, or Unix int/float)"],
-    tz: Annotated[
-        str | None,
-        "If dt is naive (no tz info), assume this IANA time zone (default UTC)",
-    ] = None,
-    unit: Annotated[
-        Literal["seconds", "milliseconds"],
-        "Output unit (default 'seconds')",
-    ] = "seconds",
-) -> float:
+def to_unix_time(data: UnixTimeInput) -> float:
     """Convert a timestamp string into Unix time.
 
     - Accepts flexible date/time strings or numeric Unix timestamps.
     - If numeric, value is returned (optionally scaled to ms).
     """
     try:
-        num = float(dt)
-        return num if unit == "seconds" else num * 1000.0
+        num = float(data.dt)
+        return num if data.unit == TimeUnit.SECONDS else num * 1000.0
     except ValueError:
         pass
 
-    aware_dt = parse_datetime(dt, assume_tz=tz)
+    aware_dt = parse_datetime(data.dt, assume_tz=data.tz)
     unix_seconds = aware_dt.timestamp()
-    return unix_seconds if unit == "seconds" else unix_seconds * 1000.0
+    return unix_seconds if data.unit == TimeUnit.SECONDS else unix_seconds * 1000.0

--- a/tests/test_tools/test_time_tools.py
+++ b/tests/test_tools/test_time_tools.py
@@ -1,5 +1,6 @@
 """Tests for time tools."""
 
+from mcp_server.models import TimezoneConvertInput, UnixTimeInput
 from mcp_server.tools.time_tools import convert_timezone, to_unix_time
 from mcp_server.utils import parse_datetime
 
@@ -7,31 +8,35 @@ from mcp_server.utils import parse_datetime
 class TestTimezoneConversion:
     def test_basic_conversion(self) -> None:
         result = convert_timezone(
-            dt="2025-08-10 09:30",
-            from_tz="Europe/Madrid",
-            to_tz="America/New_York",
+            TimezoneConvertInput(
+                dt="2025-08-10 09:30",
+                from_tz="Europe/Madrid",
+                to_tz="America/New_York",
+            )
         )
         assert "T03:30" in result or " 03:30" in result
 
     def test_format(self) -> None:
         result = convert_timezone(
-            dt="2025-08-10T09:30:00",
-            from_tz="Europe/Madrid",
-            to_tz="UTC",
-            out_format="%Y-%m-%d %H:%M",
+            TimezoneConvertInput(
+                dt="2025-08-10T09:30:00",
+                from_tz="Europe/Madrid",
+                to_tz="UTC",
+                out_format="%Y-%m-%d %H:%M",
+            )
         )
         assert result == "2025-08-10 07:30"
 
 
 class TestUnixTime:
     def test_seconds_and_milliseconds(self) -> None:
-        sec = to_unix_time("2025-08-10T09:30:00+02:00", unit="seconds")
-        ms = to_unix_time("2025-08-10T09:30:00+02:00", unit="milliseconds")
+        sec = to_unix_time(UnixTimeInput(dt="2025-08-10T09:30:00+02:00", unit="seconds"))
+        ms = to_unix_time(UnixTimeInput(dt="2025-08-10T09:30:00+02:00", unit="milliseconds"))
         assert ms > sec
         assert abs(ms - sec * 1000) < 2
 
     def test_numeric_passthrough(self) -> None:
-        sec = to_unix_time("1754899800", unit="seconds")
+        sec = to_unix_time(UnixTimeInput(dt="1754899800", unit="seconds"))
         assert abs(sec - 1754899800) < 1e-6
 
 


### PR DESCRIPTION
## Summary
- refactor `convert_timezone` and `to_unix_time` to take Pydantic input models
- document Pydantic inputs in server tool registration
- update tests for new model-based tool signatures

## Testing
- `make lint`
- `make mypy`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b033652d8832693fd8356dc2f2775