### PR TITLE
Use postponed annotations across server and scripts

### DIFF
--- a/examples/agent_client.py
+++ b/examples/agent_client.py
@@ -5,6 +5,8 @@ This example demonstrates creating an AI-powered conversational agent
 that can use MCP tools through LangChain and LangGraph.
 """
 
+from __future__ import annotations
+
 import asyncio
 import os
 

--- a/examples/simple_client.py
+++ b/examples/simple_client.py
@@ -5,6 +5,8 @@ This example demonstrates how to connect to an MCP server and use its tools.
 It uses the FastMCP Python client to interact with the server.
 """
 
+from __future__ import annotations
+
 import asyncio
 
 from fastmcp import Client

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -4,6 +4,8 @@ This package provides an MCP (Model Context Protocol) server implementation
 using the FastMCP framework.
 """
 
+from __future__ import annotations
+
 from .models import TimezoneConvertInput, ToolResult, UnixTimeInput
 
 __version__ = "0.1.0"

--- a/src/mcp_server/core/__init__.py
+++ b/src/mcp_server/core/__init__.py
@@ -1,5 +1,7 @@
 """Core package for MCP server utilities."""
 
+from __future__ import annotations
+
 from .logging import configure_logging
 
 __all__ = ["configure_logging"]

--- a/src/mcp_server/models.py
+++ b/src/mcp_server/models.py
@@ -1,5 +1,7 @@
 """Pydantic models for type safety and validation."""
 
+from __future__ import annotations
+
 from enum import Enum
 from typing import Any
 

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -1,5 +1,7 @@
 """MCP Server implementation using FastMCP."""
 
+from __future__ import annotations
+
 import structlog
 from fastmcp import FastMCP
 from starlette.middleware.cors import CORSMiddleware

--- a/src/mcp_server/tools/__init__.py
+++ b/src/mcp_server/tools/__init__.py
@@ -4,6 +4,8 @@ This package groups tool categories into separate modules. Register tools in
 server.py using mcp.tool()(function) for schema generation.
 """
 
+from __future__ import annotations
+
 from .time_tools import convert_timezone, to_unix_time
 
 __all__ = [

--- a/src/mcp_server/tools/data_tools.py
+++ b/src/mcp_server/tools/data_tools.py
@@ -1,5 +1,7 @@
 """Data processing tools (template)."""
 
+from __future__ import annotations
+
 import json
 from typing import Annotated, Any, cast
 

--- a/src/mcp_server/tools/file_tools.py
+++ b/src/mcp_server/tools/file_tools.py
@@ -1,5 +1,7 @@
 """File operation tools for the MCP server."""
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Annotated
 

--- a/src/mcp_server/tools/time_tools.py
+++ b/src/mcp_server/tools/time_tools.py
@@ -1,5 +1,7 @@
 """Time and timezone related tools."""
 
+from __future__ import annotations
+
 from zoneinfo import ZoneInfo
 
 from mcp_server.models import TimeUnit, TimezoneConvertInput, UnixTimeInput

--- a/src/mcp_server/utils.py
+++ b/src/mcp_server/utils.py
@@ -1,5 +1,7 @@
 """Utility functions for the MCP server."""
 
+from __future__ import annotations
+
 from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
 

--- a/tests/test_examples/mcp_chat_agent.py
+++ b/tests/test_examples/mcp_chat_agent.py
@@ -6,6 +6,8 @@ It supports both LLM-powered conversations (with OpenAI API key) and
 offline tool testing mode.
 """
 
+from __future__ import annotations
+
 import asyncio
 import os
 import sys


### PR DESCRIPTION
## Summary
- add `from __future__ import annotations` across `src/mcp_server` modules and typed scripts
- ensure examples and tooling scripts are future-annotation ready
- verify types and tests still pass

## Testing
- `make format`
- `make lint`
- `make mypy`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b163235c88326a764f3c6d462ebe4