### PR TITLE
Validate timezone names via zoneinfo

### DIFF
--- a/src/mcp_server/models.py
+++ b/src/mcp_server/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import Enum
 from typing import Any
+from zoneinfo import available_timezones
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -41,9 +42,10 @@ class TimezoneConvertInput(BaseModel):
 
     @field_validator("from_tz", "to_tz")
     @classmethod
-    def validate_timezone(cls, v: str) -> str:  # pragma: no cover - simple placeholder
-        """Validate IANA timezone names (placeholder)."""
-        # Could integrate with zoneinfo.available_timezones() for stricter validation.
+    def validate_timezone(cls, v: str) -> str:
+        """Validate that a timezone name exists in the system database."""
+        if v not in available_timezones():
+            raise ValueError(f"Invalid timezone: {v}")
         return v
 
 

--- a/tests/test_tools/test_time_tools.py
+++ b/tests/test_tools/test_time_tools.py
@@ -1,5 +1,7 @@
 """Tests for time tools."""
 
+import pytest
+
 from mcp_server.models import TimezoneConvertInput, UnixTimeInput
 from mcp_server.tools.time_tools import convert_timezone, to_unix_time
 from mcp_server.utils import parse_datetime
@@ -26,6 +28,14 @@ class TestTimezoneConversion:
             )
         )
         assert result == "2025-08-10 07:30"
+
+    def test_invalid_timezone(self) -> None:
+        with pytest.raises(ValueError, match="Invalid timezone"):
+            TimezoneConvertInput(
+                dt="2025-08-10 09:30",
+                from_tz="Europe/Invalid",
+                to_tz="UTC",
+            )
 
 
 class TestUnixTime:


### PR DESCRIPTION
## Summary
- validate timezones using Python's `zoneinfo.available_timezones()`
- add test coverage for invalid timezone names

## Testing
- `make format`
- `make lint`
- `make mypy`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b195df9188326ae5e69ffeae9f248