### PR TITLE
Centralize config and logging in core package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,14 +18,16 @@ This repository is a Python template for building Model Context Protocol (MCP) s
 ### Core Directories
 ```
 src/mcp_server/           # Main package - focus here for server logic
-├── server.py            # Tool registration & FastMCP server setup
-├── tools/               # Tool implementations (add new tools here)
-│   ├── time_tools.py   # Working example: timezone & time tools
-│   ├── file_tools.py   # Template for file operations
-│   └── data_tools.py   # Template for data processing
-├── models.py           # Pydantic models for validation
-├── config.py           # Server configuration
-└── utils.py            # Shared utilities
+├── core/               # Configuration and logging utilities
+│   ├── config.py       # Server configuration
+│   └── logging.py      # Logging setup
+├── server.py          # Tool registration & FastMCP server setup
+├── tools/             # Tool implementations (add new tools here)
+│   ├── time_tools.py  # Working example: timezone & time tools
+│   ├── file_tools.py  # Template for file operations
+│   └── data_tools.py  # Template for data processing
+├── models.py          # Pydantic models for validation
+└── utils.py           # Shared utilities
 
 tests/                   # Test suite
 ├── test_tools/         # Unit tests per tool module
@@ -38,6 +40,9 @@ examples/               # Usage examples
 ├── simple_client.py   # Basic FastMCP client
 └── agent_client.py    # AI agent with LangChain
 ```
+
+The `core` package centralizes configuration loading and logging helpers used by
+the server, tests, and example scripts.
 
 ### Important Files
 - `pyproject.toml` - Dependencies, build config, tool settings

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A reusable Python template for building Model Context Protocol (MCP) servers usi
 - 📦 UV Package Management: Modern Python dependency management
 - 🔍 Best Practices: Follows Python and MCP standards
 - 🎯 Production Ready: Logging, configuration, error handling
+- 🧱 Core Utilities: Centralized configuration and logging in `mcp_server.core`
 
 ## Quick Start
 
@@ -141,6 +142,9 @@ ruff check src/ tests/
 
 ```
 ├── src/mcp_server/        # Main package
+│   ├── core/              # Configuration and logging utilities
+│   │   ├── config.py      # Server configuration
+│   │   └── logging.py     # Logging setup
 │   ├── server.py          # Server implementation & tool registration
 │   ├── tools/             # Tool category modules (time_tools, file_tools, etc.)
 │   │   ├── __init__.py    # Re-exports selected tools
@@ -148,7 +152,6 @@ ruff check src/ tests/
 │   │   ├── file_tools.py  # (Template) File utilities
 │   │   └── data_tools.py  # (Template) Data processing
 │   ├── models.py          # Pydantic models
-│   ├── config.py          # Configuration
 │   └── utils.py           # Utilities
 ├── tests/                 # Test suite (per-tool modules under test_tools/)
 │   └── test_examples/     # Integration test scripts
@@ -160,6 +163,9 @@ ruff check src/ tests/
 │   └── agent_client.py    # AI agent example
 └── scripts/               # Utility scripts
 ```
+
+The `core` package houses shared configuration and logging helpers relied on by
+the server, tests, and scripts.
 
 ## Configuration
 

--- a/docs/mcp_template.md
+++ b/docs/mcp_template.md
@@ -283,7 +283,7 @@ class ToolResult(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
 ```
 
-### src/mcp_server/config.py
+### src/mcp_server/core/config.py
 
 ```python
 """Configuration management for the MCP server."""
@@ -685,8 +685,7 @@ import structlog
 
 from mcp.server.fastmcp import FastMCP
 
-from mcp_server.config import get_config
-from mcp_server.core.logging import configure_logging
+from mcp_server.core import configure_logging, get_config
 
 # Import all tools
 from mcp_server.tools import (

--- a/examples/simple_client.py
+++ b/examples/simple_client.py
@@ -11,7 +11,7 @@ import asyncio
 
 from fastmcp import Client
 
-from mcp_server.core.config import get_server_url
+from mcp_server.core import get_server_url
 
 # Server configuration
 SERVER_URL = get_server_url()

--- a/scripts/run_server.py
+++ b/scripts/run_server.py
@@ -1,6 +1,9 @@
 """Run the MCP server."""
 
+from mcp_server.core import get_config
 from mcp_server.server import main
 
 if __name__ == "__main__":  # pragma: no cover
+    cfg = get_config()
+    print(f"Starting MCP server on http://{cfg.host}:{cfg.port}{cfg.path}")
     main()

--- a/src/mcp_server/core/__init__.py
+++ b/src/mcp_server/core/__init__.py
@@ -1,7 +1,18 @@
-"""Core package for MCP server utilities."""
+"""Core package for MCP server utilities.
+
+This package centralizes configuration loading and structured logging helpers
+used throughout the project.
+"""
 
 from __future__ import annotations
 
+from .config import ServerSettings, get_config, get_server_url, load_environment
 from .logging import configure_logging
 
-__all__ = ["configure_logging"]
+__all__ = [
+    "ServerSettings",
+    "get_config",
+    "get_server_url",
+    "load_environment",
+    "configure_logging",
+]

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -6,8 +6,7 @@ import structlog
 from fastmcp import FastMCP
 from starlette.middleware.cors import CORSMiddleware
 
-from mcp_server.core.config import get_config
-from mcp_server.core.logging import configure_logging
+from mcp_server.core import configure_logging, get_config
 from mcp_server.tools import convert_timezone, to_unix_time
 
 logger = structlog.get_logger(__name__)

--- a/tests/test_examples/test_mcp_client.py
+++ b/tests/test_examples/test_mcp_client.py
@@ -12,7 +12,7 @@ from typing import Any
 import pytest
 from fastmcp import Client
 
-from mcp_server.core.config import get_server_url
+from mcp_server.core import get_server_url
 
 # Skip during unit testing since this example requires a running server
 pytestmark = pytest.mark.skip(reason="integration example requires running MCP server")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,7 +3,7 @@
 import anyio
 import pytest
 
-from mcp_server.core import config
+from mcp_server.core import get_config
 from mcp_server.server import main, mcp, register_tools
 
 
@@ -26,7 +26,7 @@ def test_environment_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MCP_HOST", "0.0.0.0")
     monkeypatch.setenv("MCP_PORT", "9001")
     monkeypatch.setenv("MCP_PATH", "/custom")
-    config.get_config.cache_clear()
+    get_config.cache_clear()
 
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- centralize configuration and logging helpers in new `mcp_server.core` package
- update server, tests, examples and scripts to import from `mcp_server.core`
- document core utilities in project guides and README

## Testing
- `make format`
- `make lint`
- `make mypy`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b1b5e43a483269c2795f984362c4a