### PR TITLE
Register file and data tools

### DIFF
--- a/src/mcp_server/tools/__init__.py
+++ b/src/mcp_server/tools/__init__.py
@@ -6,9 +6,15 @@ server.py using mcp.tool()(function) for schema generation.
 
 from __future__ import annotations
 
+from .data_tools import format_json, parse_json
+from .file_tools import list_directory, read_file
 from .time_tools import convert_timezone, to_unix_time
 
 __all__ = [
     "convert_timezone",
     "to_unix_time",
+    "read_file",
+    "list_directory",
+    "parse_json",
+    "format_json",
 ]

--- a/tests/test_tools/test_data_tools.py
+++ b/tests/test_tools/test_data_tools.py
@@ -1,0 +1,19 @@
+"""Tests for data tools."""
+
+from mcp_server.tools.data_tools import format_json, parse_json
+
+
+class TestParseJson:
+    def test_parses_json_string(self) -> None:
+        data = parse_json('{"a": 1, "b": 2}')
+        assert data == {"a": 1, "b": 2}
+
+
+class TestFormatJson:
+    def test_formats_mapping(self) -> None:
+        text = format_json({"b": 2, "a": 1}, indent=2)
+        assert text == '{\n  "a": 1,\n  "b": 2\n}'
+
+    def test_round_trip(self) -> None:
+        original = {"x": "y"}
+        assert parse_json(format_json(original)) == original

--- a/tests/test_tools/test_file_tools.py
+++ b/tests/test_tools/test_file_tools.py
@@ -1,0 +1,36 @@
+"""Tests for file tools."""
+
+from pathlib import Path
+
+import pytest
+
+from mcp_server.tools.file_tools import list_directory, read_file
+
+
+class TestReadFile:
+    def test_reads_existing_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "example.txt"
+        p.write_text("hello")
+        assert read_file(str(p)) == "hello"
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            read_file(str(tmp_path / "missing.txt"))
+
+
+class TestListDirectory:
+    def test_lists_only_files(self, tmp_path: Path) -> None:
+        file1 = tmp_path / "a.txt"
+        file1.write_text("a")
+        sub = tmp_path / "subdir"
+        sub.mkdir()
+        (sub / "b.txt").write_text("b")
+        result = list_directory(str(tmp_path))
+        assert str(file1) in result
+        assert str(sub / "b.txt") not in result
+
+    def test_path_not_directory(self, tmp_path: Path) -> None:
+        file1 = tmp_path / "a.txt"
+        file1.write_text("a")
+        with pytest.raises(NotADirectoryError):
+            list_directory(str(file1))


### PR DESCRIPTION
## Summary
- register `read_file`, `list_directory`, `parse_json`, and `format_json` with the server
- re-export new tools in `mcp_server.tools`
- add unit tests for file and data utilities

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b1feca6c08326a196418f47ca6bee