### PR TITLE
refactor: add ListeningAuthor model and refine post parsing

### DIFF
--- a/tests/test_tools/test_emplifi_tools.py
+++ b/tests/test_tools/test_emplifi_tools.py
@@ -1,11 +1,14 @@
 """Tests for simplified Emplifi Listening API tools."""
 
+from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import Response
+from pydantic import HttpUrl
 
 from mcp_server.tools.emplifi_tools import (
+    ListeningAuthor,
     ListeningPost,
     ListeningQuery,
     _get_auth_headers,
@@ -135,6 +138,9 @@ class TestFetchingPosts:
             assert posts[0].id == "post_123"
             assert posts[0].platform == "twitter"
             assert posts[0].sentiment == "positive"
+            assert isinstance(posts[0].created_time, datetime)
+            assert isinstance(posts[0].author, ListeningAuthor)
+            assert isinstance(posts[0].url, HttpUrl)
 
     @pytest.mark.asyncio
     async def test_get_recent_posts_success(self):
@@ -173,6 +179,8 @@ class TestFetchingPosts:
 
             assert len(posts) == 1
             assert posts[0].id == "recent_post"
+            assert isinstance(posts[0].created_time, datetime)
+            assert isinstance(posts[0].author, ListeningAuthor)
 
 
 class TestErrorHandling:


### PR DESCRIPTION
## Summary
- add `ListeningAuthor` Pydantic model and integrate into `ListeningPost`
- parse `created_time` as `datetime` and use `HttpUrl` for post URLs
- validate post dictionaries using `ListeningPost.model_validate`
- adjust tests for new types

## Testing
- `ruff format src/mcp_server/tools/emplifi_tools.py tests/test_tools/test_emplifi_tools.py`
- `ruff check src/mcp_server/tools/emplifi_tools.py tests/test_tools/test_emplifi_tools.py`
- `mypy src/mcp_server/tools/emplifi_tools.py tests/test_tools/test_emplifi_tools.py` *(fails: Argument 1 to "__init__" of "BaseSettings" has incompatible type...)*
- `pytest tests/test_tools/test_emplifi_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_689c29aa86208326a7e3aa52e954aa30