### PR TITLE
Use core logging for monitoring decorators

### DIFF
--- a/src/mcp_server/monitoring.py
+++ b/src/mcp_server/monitoring.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
-import logging
 import time
 from collections.abc import Awaitable, Callable
 from functools import wraps
 from typing import ParamSpec, TypeVar
 
+import structlog
+
+from mcp_server.core import configure_logging
+
 P = ParamSpec("P")
 R = TypeVar("R")
 
-logger = logging.getLogger(__name__)
+configure_logging()
+logger = structlog.get_logger(__name__)
 
 
 def monitor_performance(func: Callable[P, R]) -> Callable[P, R]:  # noqa: UP047


### PR DESCRIPTION
## Summary
- Refactor monitoring utilities to use structured logging via core `configure_logging`
- Initialize logging once before defining performance decorators

## Testing
- `make format`
- `make lint`
- `make mypy` *(fails: Argument 1 to "__init__" of "BaseSettings" has incompatible type)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c38b4e5188326ad4f2995555e0cd8